### PR TITLE
Fixed issue as per PR review.

### DIFF
--- a/app/javascript/src/components/Dashboard/Notes/DeleteAlert.jsx
+++ b/app/javascript/src/components/Dashboard/Notes/DeleteAlert.jsx
@@ -10,7 +10,7 @@ const DeleteAlert = ({ refetch, onClose, selectedNote, setSelectedNote }) => {
   const handleDelete = async () => {
     try {
       setDeleting(true);
-      await notesApi.destroy({ ids: id });
+      await notesApi.destroy({ ids: [id] });
       onClose();
       setSelectedNote({});
       refetch();


### PR DESCRIPTION
Passed an array containing a single `id` to `notesApi.destroy` function in `DeleteAlert.jsx` .

@yedhink please review.